### PR TITLE
Configure Provisioner AWS: Updated to mention bucket requirement, and…

### DIFF
--- a/docs/guides/configure-provisioner/aws/index.md
+++ b/docs/guides/configure-provisioner/aws/index.md
@@ -17,11 +17,12 @@ Amazon is a market leader in the cloud-computing space. Many commercial applicat
 
 To follow along all you'll need is the Vorteil command-line interface, which comes with Vorteil Studio.
 
-You'll also need an account with [Amazon AWS](https://aws.amazon.com/) and the ability to deploy virtual machines on [EC2](https://aws.amazon.com/ec2/). You'll also need an [access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for this account. Setting up an account with Amazon AWS is beyond the scope of this guide, but by the end of the process you should be able to provide the following information:
+You'll also need an account with [Amazon AWS](https://aws.amazon.com/) with the ability to deploy virtual machines on [EC2](https://aws.amazon.com/ec2/) and have the [vimport service role](https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role) configured on your user. You'll also need an [access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for this account. Setting up an account with Amazon AWS is beyond the scope of this guide, but by the end of the process you should be able to provide the following information:
 
     - key: the access key ID
     - secret: the access key secret
     - region: a region you have chosen where your virtual machines will be hosted
+    - bucket: a s3 bucket that you have created in the same region
 
 You'll also need to manually create a [security group](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) named "vorteil-provisioner" in the region, allowing inbound TCP traffic from anywhere to port 443.
 
@@ -30,7 +31,7 @@ You'll also need to manually create a [security group](https://docs.aws.amazon.c
 To configure an AWS provisioner takes just one command after you've found all of the relevant information from the 'Before you start' section above. Dummy values for each of the three fields listed in the 'Before you start' section are used here as well, use your own values to make AWS work.
 
 ```
-vorteil provisioners new amazon-ec2 ./aws.provisioner --key=EXAMPLEDATA --region=us-west-1 --secret=MOREEXAMPLEDATA
+vorteil provisioners new amazon-ec2 ./aws.provisioner --key=EXAMPLEDATA --region=us-west-1 --secret=MOREEXAMPLEDATA --bucket YOUR-AWS-BUCKET
 ```
 
 The command will create a file at `./aws.provisioner`, which is a base64-encoded version of the information required to provision to Amazon Web Services. An optional flag, `--passphrase`, can be used when creating the provisioner to encrypt the resulting payload. The passphrase will be required when attempting to use the provisioner in the future.


### PR DESCRIPTION
… vimport role on aws user

## Description

Small changes to show that you now need a bucket and vimport configured on your user for aws provisioning

## Purpose

- [ ] Bug fix
- [] New feature
- [X] Other

